### PR TITLE
Receive form: vendors, invoice/memo, searchable materials, total cost

### DIFF
--- a/public/css/custom.css
+++ b/public/css/custom.css
@@ -69,7 +69,30 @@ body { background: #f4f6f9; font-size: 0.875rem; }
 .gene-node { border:1px solid #dee2e6; border-radius:.4rem; padding:.4rem .8rem; display:inline-block; background:#fff; font-size:.8rem; }
 .gene-child { margin-left: 2rem; border-left: 2px dashed #adb5bd; padding-left: 1rem; }
 
-/* ── Responsive tweaks ─────────────────────────────────────────────────── */
+.material-typeahead { z-index: 5; }
+.material-dropdown {
+  z-index: 1050;
+  max-height: 240px;
+  overflow-y: auto;
+  top: 100%;
+  left: 0;
+  margin-top: 2px;
+  border: 1px solid #ced4da;
+  border-radius: .375rem;
+  background: #fff;
+}
+.material-dropdown .list-group-item {
+  cursor: pointer;
+  border-left: 0;
+  border-right: 0;
+  font-size: .85rem;
+  padding: .4rem .75rem;
+}
+.material-dropdown .list-group-item:hover,
+.material-dropdown .list-group-item.active {
+  background: #eef3f8;
+  color: var(--gem-navy);
+}
 @media (max-width:768px) {
   .navbar .d-flex { flex-wrap: wrap; gap: .3rem !important; }
 }

--- a/public/index.html
+++ b/public/index.html
@@ -107,16 +107,38 @@
       <div class="card-body">
         <form id="receiveForm" onsubmit="submitReceive(event)">
           <div class="row g-3">
-            <div class="col-md-6"><label class="form-label">Parcel Number *</label><input class="form-control" name="parcel_number" placeholder="e.g. DP-000299" /></div>
+            <div class="col-md-6"><label class="form-label">Parcel Number *</label><input class="form-control" name="parcel_number" placeholder="e.g. DP-000299" required /></div>
+            <div class="col-md-6">
+              <label class="form-label">Vendor *</label>
+              <select class="form-select" name="vendor" id="vendorSelect" required>
+                <option value="">— select vendor —</option>
+              </select>
+            </div>
             <div class="col-md-6"><label class="form-label">Vendor Parcel #</label><input class="form-control" name="vendor_parcel_number" /></div>
             <div class="col-md-6"><label class="form-label">PO Number</label><input class="form-control" name="po_number" /></div>
+
+            <div class="col-md-6">
+              <label class="form-label">Invoice Number</label>
+              <input class="form-control" name="invoice_number" id="invoiceNumber" pattern="[A-Za-z0-9][A-Za-z0-9\-_\/]*" title="Alphanumeric (letters, numbers, - _ /)" placeholder="e.g. INV-2024-0091" />
+              <div class="form-text">Alphanumeric. Invoice <strong>or</strong> Memo # required.</div>
+            </div>
+            <div class="col-md-6">
+              <label class="form-label">Memo #</label>
+              <input class="form-control" name="memo_number" id="memoNumber" pattern="[A-Za-z0-9][A-Za-z0-9\-_\/]*" title="Alphanumeric (letters, numbers, - _ /)" placeholder="e.g. MEMO-441A" />
+              <div class="form-text">Alphanumeric. Invoice <strong>or</strong> Memo # required.</div>
+            </div>
+            <div class="col-12"><div id="docReqError" class="text-danger small d-none">Enter either Invoice Number or Memo # before receiving.</div></div>
+
             <div class="col-md-6"><label class="form-label">Receipt Ref</label><input class="form-control" name="receipt_reference" /></div>
 
             <div class="col-md-6">
               <label class="form-label">Material *</label>
-              <select class="form-select" name="material" required id="materialSelect">
-                <option value="">— select —</option>
-              </select>
+              <div class="material-typeahead position-relative">
+                <input type="text" class="form-control" id="materialSearch" placeholder="Type to search gemstones…" autocomplete="off" required />
+                <input type="hidden" name="material" id="materialValue" required />
+                <div id="materialDropdown" class="material-dropdown list-group position-absolute w-100 shadow-sm d-none"></div>
+              </div>
+              <div class="form-text">Search ~250 gemstones; matching names appear as you type.</div>
             </div>
             <div class="col-md-6">
               <label class="form-label">Origin *</label>
@@ -152,17 +174,25 @@
               </select>
             </div>
 
-            <div class="col-md-3"><label class="form-label">Pieces *</label><input class="form-control" name="original_pieces" type="number" min="0" required /></div>
-            <div class="col-md-3"><label class="form-label">Weight (ct)</label><input class="form-control" name="original_weight_ct" type="number" step="0.0001" /></div>
-            <div class="col-md-3"><label class="form-label">Purchase Rate</label><input class="form-control" name="purchase_rate" type="number" step="0.01" /></div>
+            <div class="col-md-3"><label class="form-label">Pieces *</label><input class="form-control" name="original_pieces" id="recvPieces" type="number" min="0" required /></div>
+            <div class="col-md-3"><label class="form-label">Total Carat Weight *</label><input class="form-control" name="original_weight_ct" id="recvWeight" type="number" step="0.0001" min="0" required /></div>
+            <div class="col-md-3"><label class="form-label">Purchase Rate *</label><input class="form-control" name="purchase_rate" id="recvRate" type="number" step="0.01" min="0" required /></div>
             <div class="col-md-3">
-              <label class="form-label">Pricing Unit</label>
-              <select class="form-select" name="pricing_unit">
+              <label class="form-label">Pricing Unit *</label>
+              <select class="form-select" name="pricing_unit" id="recvPricingUnit" required>
                 <option value="per_carat">Per Carat</option>
                 <option value="per_piece">Per Piece</option>
                 <option value="per_gram">Per Gram</option>
                 <option value="per_parcel">Per Parcel</option>
               </select>
+            </div>
+            <div class="col-md-6">
+              <label class="form-label">Total Cost of Parcel *</label>
+              <div class="input-group">
+                <span class="input-group-text">$</span>
+                <input class="form-control" name="landed_cost" id="recvTotalCost" type="number" step="0.01" min="0" required />
+              </div>
+              <div class="form-text">Auto-calculated from rate × weight/pieces; you may override.</div>
             </div>
 
             <div class="col-md-4"><label class="form-label">Site</label><input class="form-control" name="site" placeholder="Main Office" /></div>

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -10,7 +10,11 @@ function showView(name, parcelId) {
   if (name === 'parcels')   loadParcels();
   if (name === 'detail' && parcelId) loadDetail(parcelId);
   if (name === 'uat')       renderUAT();
-  if (name === 'receive')   populateMaterialDropdowns();
+  if (name === 'receive') {
+    populateMaterialDropdowns();
+    populateVendorDropdown();
+    bindReceiveCostListeners();
+  }
   if (name === 'disposition' && parcelId) loadDisposition(parcelId);
 }
 
@@ -131,16 +135,140 @@ async function loadParcels() {
 
 async function populateMaterialDropdowns() {
   const materials = await api('/api/meta/materials');
-  ['materialSelect', 'filterMaterial'].forEach(id => {
-    const sel = document.getElementById(id);
-    if (!sel) return;
+  allMaterials = materials;
+  // Keep list-filter select populated for parcel inventory filter
+  const sel = document.getElementById('filterMaterial');
+  if (sel) {
     materials.forEach(m => {
       if (!sel.querySelector(`option[value="${m}"]`)) {
         const o = document.createElement('option');
-        o.value = m; o.text = m.replace(/_/g,' ');
+        o.value = m; o.text = labelMaterial(m);
         sel.appendChild(o);
       }
     });
+  }
+  initMaterialTypeahead();
+}
+
+async function populateVendorDropdown() {
+  const vendors = await api('/api/meta/vendors');
+  const sel = document.getElementById('vendorSelect');
+  if (!sel) return;
+  const current = sel.value;
+  sel.innerHTML = '<option value="">— select vendor —</option>';
+  vendors.forEach(v => {
+    const o = document.createElement('option');
+    o.value = v; o.text = v;
+    sel.appendChild(o);
+  });
+  if (current) sel.value = current;
+}
+
+function labelMaterial(m) {
+  return String(m || '').replace(/_/g, ' ');
+}
+
+/* ── Material typeahead ─────────────────────────────────────────────────── */
+let allMaterials = [];
+let materialHighlight = -1;
+
+function initMaterialTypeahead() {
+  const input = document.getElementById('materialSearch');
+  const hidden = document.getElementById('materialValue');
+  const drop = document.getElementById('materialDropdown');
+  if (!input || !drop || input.dataset.bound) return;
+  input.dataset.bound = '1';
+
+  input.addEventListener('input', () => {
+    hidden.value = '';
+    materialHighlight = -1;
+    renderMaterialSuggestions(input.value);
+    recalcReceiveTotal();
+  });
+  input.addEventListener('focus', () => renderMaterialSuggestions(input.value));
+  input.addEventListener('keydown', (e) => {
+    const items = drop.querySelectorAll('[data-value]');
+    if (e.key === 'ArrowDown') {
+      e.preventDefault();
+      materialHighlight = Math.min(materialHighlight + 1, items.length - 1);
+      syncMaterialHighlight(items);
+    } else if (e.key === 'ArrowUp') {
+      e.preventDefault();
+      materialHighlight = Math.max(materialHighlight - 1, 0);
+      syncMaterialHighlight(items);
+    } else if (e.key === 'Enter') {
+      if (materialHighlight >= 0 && items[materialHighlight]) {
+        e.preventDefault();
+        selectMaterial(items[materialHighlight].dataset.value);
+      }
+    } else if (e.key === 'Escape') {
+      drop.classList.add('d-none');
+    }
+  });
+  document.addEventListener('click', (e) => {
+    if (!e.target.closest('.material-typeahead')) drop.classList.add('d-none');
+  });
+}
+
+function syncMaterialHighlight(items) {
+  items.forEach((el, i) => el.classList.toggle('active', i === materialHighlight));
+  if (items[materialHighlight]) items[materialHighlight].scrollIntoView({ block: 'nearest' });
+}
+
+function renderMaterialSuggestions(q) {
+  const drop = document.getElementById('materialDropdown');
+  if (!drop) return;
+  const query = (q || '').trim().toLowerCase().replace(/\s+/g, '_');
+  const matches = allMaterials
+    .filter(m => !query || m.includes(query) || labelMaterial(m).toLowerCase().includes(query.replace(/_/g, ' ')))
+    .slice(0, 40);
+  if (!matches.length) {
+    drop.innerHTML = `<div class="list-group-item text-muted">No matching gemstones</div>`;
+    drop.classList.remove('d-none');
+    return;
+  }
+  drop.innerHTML = matches.map(m =>
+    `<button type="button" class="list-group-item list-group-item-action" data-value="${m}">${labelMaterial(m)}</button>`
+  ).join('');
+  drop.querySelectorAll('[data-value]').forEach(btn => {
+    btn.addEventListener('mousedown', (e) => {
+      e.preventDefault();
+      selectMaterial(btn.dataset.value);
+    });
+  });
+  drop.classList.remove('d-none');
+}
+
+function selectMaterial(value) {
+  document.getElementById('materialValue').value = value;
+  document.getElementById('materialSearch').value = labelMaterial(value);
+  document.getElementById('materialDropdown').classList.add('d-none');
+  materialHighlight = -1;
+}
+
+function recalcReceiveTotal() {
+  const rate = +document.getElementById('recvRate')?.value || 0;
+  const weight = +document.getElementById('recvWeight')?.value || 0;
+  const pieces = +document.getElementById('recvPieces')?.value || 0;
+  const unit = document.getElementById('recvPricingUnit')?.value || 'per_carat';
+  const totalEl = document.getElementById('recvTotalCost');
+  if (!totalEl) return;
+  let total = 0;
+  if (unit === 'per_carat') total = rate * weight;
+  else if (unit === 'per_piece') total = rate * pieces;
+  else if (unit === 'per_parcel') total = rate;
+  else total = rate * weight;
+  totalEl.value = total ? total.toFixed(2) : '';
+}
+
+function bindReceiveCostListeners() {
+  ['recvRate', 'recvWeight', 'recvPieces', 'recvPricingUnit'].forEach(id => {
+    const el = document.getElementById(id);
+    if (el && !el.dataset.costBound) {
+      el.dataset.costBound = '1';
+      el.addEventListener('input', recalcReceiveTotal);
+      el.addEventListener('change', recalcReceiveTotal);
+    }
   });
 }
 
@@ -191,6 +319,10 @@ async function loadDetail(id) {
               <div class="col-md-3"><small class="text-muted">Origin</small><br>${p.origin_country || '—'}</div>
               <div class="col-md-3"><small class="text-muted">Screening</small><br>${p.screening_status}</div>
               <div class="col-md-3"><small class="text-muted">KP Certificate</small><br>${p.kimberley_cert || '—'}</div>
+              <div class="col-md-3"><small class="text-muted">Vendor</small><br>${p.vendor || '—'}</div>
+              <div class="col-md-3"><small class="text-muted">Invoice #</small><br>${p.invoice_number || '—'}</div>
+              <div class="col-md-3"><small class="text-muted">Memo #</small><br>${p.memo_number || '—'}</div>
+              <div class="col-md-3"><small class="text-muted">Vendor Parcel #</small><br>${p.vendor_parcel_number || '—'}</div>
             </div>
           </div>
         </div>
@@ -355,12 +487,50 @@ async function submitReceive(e) {
   e.preventDefault();
   const form = e.target;
   const data = Object.fromEntries(new FormData(form).entries());
-  // Convert numeric fields
-  ['size_min_mm','size_max_mm','original_pieces','original_weight_ct','purchase_rate'].forEach(k => { if (data[k]) data[k] = +data[k]; });
+  const invoice = (data.invoice_number || '').trim();
+  const memo = (data.memo_number || '').trim();
+  const errEl = document.getElementById('docReqError');
+
+  if (!invoice && !memo) {
+    errEl?.classList.remove('d-none');
+    toast('Either Invoice Number or Memo # is required', 'danger');
+    return;
+  }
+  errEl?.classList.add('d-none');
+
+  if (!data.material) {
+    toast('Select a material from the search list', 'warning');
+    document.getElementById('materialSearch')?.focus();
+    return;
+  }
+  if (!data.vendor) {
+    toast('Vendor is required', 'warning');
+    return;
+  }
+  if (data.original_weight_ct === '' || data.original_weight_ct == null) {
+    toast('Total carat weight is required', 'warning');
+    return;
+  }
+  if (data.purchase_rate === '' || data.purchase_rate == null) {
+    toast('Purchase rate is required', 'warning');
+    return;
+  }
+  if (data.landed_cost === '' || data.landed_cost == null) {
+    toast('Total cost of parcel is required', 'warning');
+    return;
+  }
+
+  ['size_min_mm','size_max_mm','original_pieces','original_weight_ct','purchase_rate','landed_cost'].forEach(k => {
+    if (data[k] !== undefined && data[k] !== '') data[k] = +data[k];
+  });
+
   try {
     const r = await api('/api/parcels', 'POST', data);
-    toast(`Parcel <strong>${r.parcel_number}</strong> received successfully`, 'success');
+    toast(`Parcel <strong>${r.parcel_number}</strong> received · total cost ${fmtUSD(r.landed_cost)}`, 'success');
     form.reset();
+    document.getElementById('materialValue').value = '';
+    const owner = form.querySelector('[name="owner"]');
+    if (owner) owner.value = 'Company';
     showView('detail', r.id);
   } catch(err) { toast(err.message, 'danger'); }
 }

--- a/server.js
+++ b/server.js
@@ -126,15 +126,54 @@ app.get('/api/parcels/:id', (req, res) => {
 
 // Create / Receive a new parcel
 app.post('/api/parcels', (req, res) => {
+  try {
   const db = getDb();
   const d  = req.body;
   const id = uuidv4();
   const num = d.parcel_number || `PCL-${Date.now()}`;
-  const cost = (d.purchase_rate || 0) * (d.pricing_unit === 'per_carat' ? (d.original_weight_ct || 0) : (d.original_pieces || 0));
+
+  const invoice = (d.invoice_number || '').trim();
+  const memoNum = (d.memo_number || '').trim();
+  if (!invoice && !memoNum) {
+    return res.status(400).json({ error: 'Either Invoice Number or Memo # is required' });
+  }
+  const alnumDoc = /^[A-Za-z0-9][A-Za-z0-9\-_/]*$/;
+  if (invoice && !alnumDoc.test(invoice)) {
+    return res.status(400).json({ error: 'Invoice Number must be alphanumeric (letters, numbers, - _ / allowed)' });
+  }
+  if (memoNum && !alnumDoc.test(memoNum)) {
+    return res.status(400).json({ error: 'Memo # must be alphanumeric (letters, numbers, - _ / allowed)' });
+  }
+  if (d.original_weight_ct === undefined || d.original_weight_ct === null || d.original_weight_ct === '') {
+    return res.status(400).json({ error: 'Total carat weight is required' });
+  }
+  if (d.purchase_rate === undefined || d.purchase_rate === null || d.purchase_rate === '') {
+    return res.status(400).json({ error: 'Purchase rate is required' });
+  }
+  if (!d.material) return res.status(400).json({ error: 'Material is required' });
+  if (!d.vendor) return res.status(400).json({ error: 'Vendor is required' });
+
+  const weight = +d.original_weight_ct;
+  const rate = +d.purchase_rate;
+  const pieces = +(d.original_pieces || 0);
+  const unit = d.pricing_unit || 'per_carat';
+  let cost;
+  if (d.landed_cost != null && d.landed_cost !== '') {
+    cost = +d.landed_cost;
+  } else if (unit === 'per_carat') {
+    cost = +(rate * weight).toFixed(2);
+  } else if (unit === 'per_piece') {
+    cost = +(rate * pieces).toFixed(2);
+  } else if (unit === 'per_parcel') {
+    cost = +rate.toFixed(2);
+  } else {
+    cost = +(rate * weight).toFixed(2);
+  }
 
   db.prepare(`
     INSERT INTO parcels (
-      id, parcel_number, vendor_parcel_number, po_number, receipt_reference,
+      id, parcel_number, vendor_parcel_number, vendor, invoice_number, memo_number,
+      po_number, receipt_reference,
       status, lifecycle_stage, material, material_origin, condition, shape,
       size_min_mm, size_max_mm, color, color_range_max, clarity, clarity_range_max,
       treatment, fluorescence, origin_country,
@@ -143,7 +182,8 @@ app.post('/api/parcels', (req, res) => {
       site, vault, bin_location, custodian, owner, legal_entity,
       screening_status, created_by, notes
     ) VALUES (
-      @id, @parcel_number, @vendor_parcel_number, @po_number, @receipt_reference,
+      @id, @parcel_number, @vendor_parcel_number, @vendor, @invoice_number, @memo_number,
+      @po_number, @receipt_reference,
       'active', 'available', @material, @material_origin, @condition, @shape,
       @size_min_mm, @size_max_mm, @color, @color_range_max, @clarity, @clarity_range_max,
       @treatment, @fluorescence, @origin_country,
@@ -155,6 +195,9 @@ app.post('/api/parcels', (req, res) => {
   `).run({
     id, parcel_number: num,
     vendor_parcel_number: d.vendor_parcel_number || null,
+    vendor: d.vendor || null,
+    invoice_number: invoice || null,
+    memo_number: memoNum || null,
     po_number: d.po_number || null,
     receipt_reference: d.receipt_reference || null,
     material: d.material, material_origin: d.material_origin || 'natural',
@@ -164,11 +207,11 @@ app.post('/api/parcels', (req, res) => {
     clarity: d.clarity || null, clarity_range_max: d.clarity_range_max || null,
     treatment: d.treatment || 'none', fluorescence: d.fluorescence || 'none',
     origin_country: d.origin_country || null,
-    original_pieces: d.original_pieces || 0,
-    original_weight_ct: d.original_weight_ct || 0,
-    purchase_rate: d.purchase_rate || 0,
-    pricing_unit: d.pricing_unit || 'per_carat',
-    landed_cost: d.landed_cost || cost,
+    original_pieces: pieces,
+    original_weight_ct: weight,
+    purchase_rate: rate,
+    pricing_unit: unit,
+    landed_cost: cost,
     currency: d.currency || 'USD',
     site: d.site || null, vault: d.vault || null,
     bin_location: d.bin_location || null,
@@ -192,15 +235,19 @@ app.post('/api/parcels', (req, res) => {
        @date, @date, @by, 'PURCHASE', @notes)
   `).run({
     id: uuidv4(), parcel_id: id,
-    ref: d.receipt_reference || null, doc: d.po_number || null,
-    pieces: d.original_pieces || 0, weight: d.original_weight_ct || 0,
-    cost: d.landed_cost || cost,
+    ref: invoice || memoNum || d.receipt_reference || null,
+    doc: d.po_number || null,
+    pieces, weight, cost,
     loc: [d.vault, d.bin_location].filter(Boolean).join(' / ') || null,
     cust: d.custodian || null, date: today(),
-    by: d.created_by || 'uat_user', notes: d.notes || null,
+    by: d.created_by || 'uat_user',
+    notes: [d.notes, d.vendor ? `Vendor: ${d.vendor}` : null, invoice ? `Invoice: ${invoice}` : null, memoNum ? `Memo: ${memoNum}` : null].filter(Boolean).join(' | ') || null,
   });
 
-  res.status(201).json({ id, parcel_number: num });
+  res.status(201).json({ id, parcel_number: num, landed_cost: cost });
+  } catch (e) {
+    res.status(e.status || 500).json({ error: e.message });
+  }
 });
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -1324,8 +1371,11 @@ app.get('/api/parcels/:id/genealogy', (req, res) => {
   res.json(buildTree(rootId));
 });
 
+const { MATERIALS, VENDORS } = require('./src/materials');
+
 // Lookup fields (for dropdowns)
-app.get('/api/meta/materials', (_req, res) => res.json(['natural_diamond','lab_diamond','ruby','sapphire','emerald','alexandrite','pearl','opal','spinel','tanzanite','tourmaline','bead','finding','scrap','unknown']));
+app.get('/api/meta/materials', (_req, res) => res.json(MATERIALS));
+app.get('/api/meta/vendors', (_req, res) => res.json(VENDORS));
 app.get('/api/meta/lifecycle',  (_req, res) => res.json(['available','in_production','on_memo','quarantined','reserved','closed']));
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/src/database.js
+++ b/src/database.js
@@ -112,6 +112,9 @@ function initSchema() {
       parent_parcel_id    TEXT,
       root_parcel_id      TEXT,
       vendor_parcel_number TEXT,
+      vendor              TEXT,
+      invoice_number      TEXT,
+      memo_number         TEXT,
       po_number           TEXT,
       receipt_reference   TEXT,
 
@@ -257,6 +260,19 @@ function initSchema() {
     CREATE INDEX IF NOT EXISTS idx_rel_parent       ON parcel_relationships(parent_parcel_id);
     CREATE INDEX IF NOT EXISTS idx_rel_child        ON parcel_relationships(child_parcel_id);
   `);
+
+  // Migrate existing DBs created before vendor / invoice / memo columns
+  const cols = _db.exec('PRAGMA table_info(parcels)');
+  const names = new Set();
+  if (cols[0]) {
+    const nameIdx = cols[0].columns.indexOf('name');
+    for (const row of cols[0].values) names.add(row[nameIdx]);
+  }
+  for (const col of ['vendor', 'invoice_number', 'memo_number']) {
+    if (!names.has(col)) {
+      _db.run(`ALTER TABLE parcels ADD COLUMN ${col} TEXT`);
+    }
+  }
 }
 
 async function reloadDb() {

--- a/src/materials.js
+++ b/src/materials.js
@@ -1,0 +1,120 @@
+'use strict';
+
+/**
+ * Exhaustive-enough gemstone / material catalog for UAT typeahead.
+ * ~250 entries — small enough to ship in-memory and filter client-side.
+ */
+const MATERIALS = [
+  // Diamonds & carbon
+  'natural_diamond', 'lab_diamond', 'diamond', 'carbonado', 'lonsdaleite',
+  // Corundum
+  'ruby', 'sapphire', 'padparadscha', 'star_ruby', 'star_sapphire',
+  // Beryl
+  'emerald', 'aquamarine', 'morganite', 'heliodor', 'goshenite', 'red_beryl', 'bixbite',
+  // Chrysoberyl
+  'alexandrite', 'chrysoberyl', 'cats_eye_chrysoberyl',
+  // Quartz family
+  'amethyst', 'citrine', 'rose_quartz', 'smoky_quartz', 'rock_crystal', 'aventurine',
+  'prasiolite', 'amethyst_citrine', 'tiger_eye', 'hawk_eye', 'bull_eye', 'jasper',
+  'chalcedony', 'agate', 'carnelian', 'onyx', 'sardonyx', 'chrysoprase', 'bloodstone',
+  'heliotrope', 'plasma', 'sard', 'flint', 'chert',
+  // Garnet group
+  'garnet', 'almandine', 'pyrope', 'spessartine', 'grossular', 'andradite', 'uvarovite',
+  'tsavorite', 'demantoid', 'mali_garnet', 'rhodolite', 'hessonite', 'melanite', 'topazolite',
+  // Tourmaline
+  'tourmaline', 'rubellite', 'indicolite', 'paraiba_tourmaline', 'verdelite',
+  'achroite', 'dravite', 'schorl', 'watermelon_tourmaline', 'chrome_tourmaline',
+  // Topaz
+  'topaz', 'imperial_topaz', 'blue_topaz', 'pink_topaz', 'yellow_topaz', 'white_topaz',
+  // Spinel
+  'spinel', 'red_spinel', 'blue_spinel', 'pink_spinel', 'black_spinel', 'cobalt_spinel',
+  // Zircon & cubic
+  'zircon', 'blue_zircon', 'hyacinth', 'cubic_zirconia',
+  // Peridot / olivine
+  'peridot', 'olivine', 'chrysolite',
+  // Tanzanite / zoisite / epidote
+  'tanzanite', 'zoisite', 'thulite', 'anyolite', 'epidote', 'unakite',
+  // Feldspar
+  'moonstone', 'labradorite', 'sunstone', 'amazonite', 'orthoclase', 'microcline',
+  'albite', 'oligoclase', 'andesine', 'spectrolite', 'rainbow_moonstone',
+  // Opal
+  'opal', 'black_opal', 'white_opal', 'fire_opal', 'boulder_opal', 'crystal_opal',
+  'water_opal', 'matrix_opal', 'ethiopian_opal', 'mexican_opal',
+  // Jade
+  'jade', 'jadeite', 'nephrite', 'imperial_jade',
+  // Turquoise & related
+  'turquoise', 'variscite', 'chrysocolla', 'larimar',
+  // Lapis & lazurite
+  'lapis_lazuli', 'lazurite', 'sodalite', 'hauyne',
+  // Pearl & organic
+  'pearl', 'akoya_pearl', 'south_sea_pearl', 'tahitian_pearl', 'freshwater_pearl',
+  'keshi_pearl', 'mabe_pearl', 'conch_pearl', 'melo_pearl', 'abalone_pearl',
+  'coral', 'amber', 'jet', 'ivory', 'mother_of_pearl', 'nacre', 'copal',
+  // Fancy / rare
+  'tanzanite', 'kunzite', 'hiddenite', 'spodumene', 'iolite', 'cordierite',
+  'andalusite', 'chiastolite', 'kyanite', 'sillimanite', 'apatite', 'benitoite',
+  'painite', 'taaffeite', 'musgravite', 'jeremejevite', 'grandidierite',
+  'pezzottaite', 'serendibite', 'hibonite', 'poudretteite', 'jeremejevite',
+  // Sphene / titanite / scapolite etc.
+  'sphene', 'titanite', 'scapolite', 'diopside', 'chrome_diopside', 'enstatite',
+  'hypersthene', 'broncite', 'augite', 'hedenbergite',
+  // Corundum-adjacent / other oxides
+  'rutile', 'brookite', 'anatase', 'cassiterite', 'hematite', 'magnetite',
+  'pyrite', 'marcasite', 'goethite', 'limonite',
+  // Sulfides / unusual
+  'sphalerite', 'cinnabar', 'realgar', 'orpiment',
+  // Carbonates
+  'malachite', 'azurite', 'rhodochrosite', 'smithsonite', 'aragonite', 'calcite',
+  'magnesite', 'siderite', 'cerussite', 'witherite',
+  // Phosphates
+  'apatite', 'turquoise', 'variscite', 'amblygonite', 'brazilianite', 'lazulite',
+  'wardite', 'childrenite',
+  // Sulfates
+  'gypsum', 'selenite', 'alabaster', 'anhydrite', 'celestine', 'barite',
+  // Fluorite / halides
+  'fluorite', 'halite', 'cryolite',
+  // Silicates misc
+  'prehnite', 'apophyllite', 'datolite', 'danburite', 'axinite', 'vesuvianite',
+  'idocrase', 'californite', 'serpentine', 'bowenite', 'williamsite', 'chrysotile',
+  'talc', 'steatite', 'pyrophyllite', 'chlorite',
+  // Zeolites
+  'stilbite', 'heulandite', 'natrolite', 'analcime', 'thomsonite',
+  // Obsidian & volcanic glass
+  'obsidian', 'snowflake_obsidian', 'mahogany_obsidian', 'rainbow_obsidian',
+  'apache_tear', 'moldavite', 'tektite', 'libyan_desert_glass',
+  // Synthetic / simulant / commercial
+  'moissanite', 'synthetic_ruby', 'synthetic_sapphire', 'synthetic_emerald',
+  'synthetic_alexandrite', 'glass', 'paste', 'strass', 'yttrium_aluminum_garnet',
+  'gadolinium_gallium_garnet', 'lithium_niobate',
+  // Beads / findings / scrap / ops
+  'bead', 'strand', 'finding', 'component', 'scrap', 'scrap_metal', 'gold_scrap',
+  'silver_scrap', 'platinum_scrap', 'mixed_parcel', 'unknown',
+  // Additional colored stones commonly traded
+  'blue_sapphire', 'yellow_sapphire', 'pink_sapphire', 'white_sapphire',
+  'green_sapphire', 'purple_sapphire', 'orange_sapphire', 'parti_sapphire',
+  'fancy_sapphire', 'kanchanaburi_sapphire', 'ceylon_sapphire', 'kashmir_sapphire',
+  'burmese_ruby', 'mozambican_ruby', 'thai_ruby',
+  'colombian_emerald', 'zambian_emerald', 'brazilian_emerald',
+  'paraiba', 'cuprian_tourmaline', 'chrome_tourmaline',
+  'mandarin_garnet', 'malaia_garnet', 'color_change_garnet', 'color_change_sapphire',
+  'color_change_spinel', 'color_change_diaspore', 'zultanite', 'csarite',
+  'hackmanite', 'charoite', 'sugilite', 'howlite', 'magnesite', 'dolomite',
+  'rhodonite', 'thulite', 'eudialyte', 'larvikite', 'nuummite', 'pietersite',
+  'tigers_eye', 'hawks_eye', 'cats_eye', 'silk_sapphire',
+  'black_diamond', 'champagne_diamond', 'cognac_diamond', 'yellow_diamond',
+  'pink_diamond', 'blue_diamond', 'green_diamond', 'red_diamond', 'argyle_diamond',
+  'salt_and_pepper_diamond', 'rough_diamond', 'melee_diamond', 'calibrated_sapphire',
+  'calibrated_ruby', 'calibrated_emerald',
+].filter((v, i, a) => a.indexOf(v) === i).sort();
+
+const VENDORS = [
+  'RUCHI DIAMONDS',
+  'DHARM INTERNATIONAL',
+  'DALUMI DIAMOND CORP',
+  'KASPHUL LLC',
+  'PALA INTERNATIONAL',
+  'CHINASTONE LLC',
+  'TSAVORITE FACTORY',
+];
+
+module.exports = { MATERIALS, VENDORS };

--- a/uat/smoke-tests.js
+++ b/uat/smoke-tests.js
@@ -64,6 +64,8 @@ async function run() {
   {
     const r = await req('POST', '/api/parcels', {
       parcel_number: 'DP-SMOKE-001',
+      vendor: 'RUCHI DIAMONDS',
+      invoice_number: 'INV-SMOKE-001',
       material: 'natural_diamond', material_origin: 'natural',
       shape: 'Round Brilliant', size_min_mm: 2.0, size_max_mm: 2.2,
       color: 'G', color_range_max: 'H', clarity: 'SI1', clarity_range_max: 'SI2',
@@ -75,8 +77,29 @@ async function run() {
     assert('Receive creates parcel', r.status === 201, JSON.stringify(r.data));
     const d = await req('GET', `/api/parcels/${r.data.id}`);
     assert('Receipt landed cost = 2100', Math.abs(d.data.landed_cost - 2100) < 0.01, `got ${d.data.landed_cost}`);
+    assert('Vendor stored', d.data.vendor === 'RUCHI DIAMONDS');
+    assert('Invoice stored', d.data.invoice_number === 'INV-SMOKE-001');
     const tx = await req('GET', `/api/parcels/${r.data.id}/transactions`);
     assert('Receipt ledger entry exists', tx.data.some(t => t.transaction_type === 'receipt'));
+  }
+
+  // Invoice/memo rule
+  {
+    const r = await req('POST', '/api/parcels', {
+      parcel_number: 'DP-SMOKE-NODOC',
+      vendor: 'KASPHUL LLC',
+      material: 'sapphire', material_origin: 'natural',
+      original_pieces: 5, original_weight_ct: 2.0, purchase_rate: 100,
+    });
+    assert('Receive without invoice/memo rejected', r.status === 400 && /invoice|memo/i.test(r.data.error), JSON.stringify(r.data));
+  }
+
+  // Materials catalog size
+  {
+    const r = await req('GET', '/api/meta/materials');
+    assert('Materials catalog is searchable size', r.status === 200 && r.data.length >= 150, `got ${r.data?.length}`);
+    const v = await req('GET', '/api/meta/vendors');
+    assert('Vendors list has 7 entries', v.status === 200 && v.data.length === 7, `got ${v.data?.length}`);
   }
 
   // UAT-02 Split
@@ -140,6 +163,7 @@ async function run() {
     await reset();
     const recv = await req('POST', '/api/parcels', {
       parcel_number: 'DUAL-UNIT-001', material: 'natural_diamond', material_origin: 'natural',
+      vendor: 'PALA INTERNATIONAL', memo_number: 'MEMO-DUAL-1',
       original_pieces: 10, original_weight_ct: 3.0, purchase_rate: 500, pricing_unit: 'per_carat',
       screening_status: 'screened',
     });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Enhances the **Receive New Parcel** UAT form with vendor selection, document references, searchable materials, and mandatory commercial fields.

### Changes

- **Vendor** dropdown (required):
  - RUCHI DIAMONDS
  - DHARM INTERNATIONAL
  - DALUMI DIAMOND CORP
  - KASPHUL LLC
  - PALA INTERNATIONAL
  - CHINASTONE LLC
  - TSAVORITE FACTORY
- **Invoice Number** and **Memo #** — alphanumeric; **at least one required** (client + API)
- **Material** typeahead over **~300 gemstones** — type to filter, arrow keys / click to select
- **Total carat weight** and **purchase rate** are mandatory
- **Total cost of parcel** — auto-calculated from rate × weight/pieces (overridable)

### Test

```bash
npm install && npm run seed && npm start
npm run test:smoke   # 41/41 passing
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ee39a162-46c0-4ae1-a530-c13848652dba?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ee39a162-46c0-4ae1-a530-c13848652dba&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

